### PR TITLE
OAuth 인증 후 로직 / 계정 정보 조회 기능 추가

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,63 @@
 "use client";
 import React, { useState, useEffect, ReactElement } from "react";
 import styled from "styled-components";
+import { useAppDispatch } from "store/hooks";
+import { userLoggedIn, userLoggedOut } from "store/features/user/authSlice";
+
+const Home = () => {
+  const [scrollNum, setScrollNum] = useState(0);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const authToken = window.localStorage.getItem("oauth_provider_token");
+    authToken ? dispatch(userLoggedIn()) : dispatch(userLoggedOut());
+  }, [dispatch]);
+
+  useEffect(() => {
+    const allParallaxImage = document.querySelectorAll(
+      `${ParallaxImageCommon}`
+    );
+    const totalNum = allParallaxImage.length;
+
+    // window.addEventListener("scroll", () => {
+    //   setScrollNum(window.scrollY);
+
+    //   allParallaxImage.forEach((item, index) => {
+    //     item.style.transform = `perspective(500px) translate3d(0,0, ${
+    //       scrollNum / (2 * (totalNum - index))
+    //     }px)`;
+    //   });
+    // });
+  }, [scrollNum]);
+
+  return (
+    <>
+      <MainPageSection>
+        <ImageWrap>
+          <ParallaxImageCommon></ParallaxImageCommon>
+          <ParallaxImageCommon></ParallaxImageCommon>
+          <ParallaxImageCommon></ParallaxImageCommon>
+          <ParallaxImageCommon></ParallaxImageCommon>
+          <ParallaxImageCommon></ParallaxImageCommon>
+        </ImageWrap>
+      </MainPageSection>
+      <SubPageSection>
+        <SubPageInnerWrap>
+          <PhraseWrap>
+            <PhraseImg
+              src="/images/main_phrase.png"
+              alt="집에서 놀고 있는 캠핑 용품으로 용돈 벌어요!"
+            />
+          </PhraseWrap>
+          <BtnWrap>
+            <BtnImgCommon src="/images/btn_rental.png" alt="대여해요" />
+            <BtnImgCommon src="/images/btn_vote.png" alt="익명투표" />
+          </BtnWrap>
+        </SubPageInnerWrap>
+      </SubPageSection>
+    </>
+  );
+};
 
 const MainPageSection = styled.section`
   width: 100%;
@@ -78,54 +135,5 @@ const BtnImgCommon = styled.img`
   border-radius: 20%;
   cursor: pointer;
 `;
-
-const Home = () => {
-  const [scrollNum, setScrollNum] = useState(0);
-
-  useEffect(() => {
-    const allParallaxImage = document.querySelectorAll(
-      `${ParallaxImageCommon}`
-    );
-    const totalNum = allParallaxImage.length;
-
-    // window.addEventListener("scroll", () => {
-    //   setScrollNum(window.scrollY);
-
-    //   allParallaxImage.forEach((item, index) => {
-    //     item.style.transform = `perspective(500px) translate3d(0,0, ${
-    //       scrollNum / (2 * (totalNum - index))
-    //     }px)`;
-    //   });
-    // });
-  }, [scrollNum]);
-
-  return (
-    <>
-      <MainPageSection>
-        <ImageWrap>
-          <ParallaxImageCommon></ParallaxImageCommon>
-          <ParallaxImageCommon></ParallaxImageCommon>
-          <ParallaxImageCommon></ParallaxImageCommon>
-          <ParallaxImageCommon></ParallaxImageCommon>
-          <ParallaxImageCommon></ParallaxImageCommon>
-        </ImageWrap>
-      </MainPageSection>
-      <SubPageSection>
-        <SubPageInnerWrap>
-          <PhraseWrap>
-            <PhraseImg
-              src="/images/main_phrase.png"
-              alt="집에서 놀고 있는 캠핑 용품으로 용돈 벌어요!"
-            />
-          </PhraseWrap>
-          <BtnWrap>
-            <BtnImgCommon src="/images/btn_rental.png" alt="대여해요" />
-            <BtnImgCommon src="/images/btn_vote.png" alt="익명투표" />
-          </BtnWrap>
-        </SubPageInnerWrap>
-      </SubPageSection>
-    </>
-  );
-};
 
 export default Home;

--- a/components/user/UserIcon.tsx
+++ b/components/user/UserIcon.tsx
@@ -1,7 +1,12 @@
+import { useRouter } from "next/navigation";
 import { Avatar } from "antd";
 import { UserOutlined } from "@ant-design/icons";
+import { useAppSelector } from "store/hooks";
 
 const UserIcon = () => {
+  const router = useRouter();
+  const { isLoggedIn } = useAppSelector((state) => state.auth);
+
   return (
     <Avatar
       icon={<UserOutlined />}
@@ -12,6 +17,9 @@ const UserIcon = () => {
         border: "2px solid black",
         cursor: "pointer",
       }}
+      onClick={() =>
+        isLoggedIn ? router.push("/profile") : router.push("/login")
+      }
     />
   );
 };

--- a/components/user/UserInfo.tsx
+++ b/components/user/UserInfo.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const UserInfo = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <span style={{ fontWeight: "bold", marginRight: "7px" }}>{children}</span>
+  );
+};
+
+export default UserInfo;

--- a/components/user/UserProfile.tsx
+++ b/components/user/UserProfile.tsx
@@ -1,20 +1,72 @@
-import React, { useCallback } from "react";
+import React, { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { Card, Button } from "antd";
 import styled from "styled-components";
 import { supabase } from "src/lib/supabase";
-
-const AccountBox = styled(Card)`
-  width: 100%;
-  margin: auto;
-  margin-top: 100px;
-`;
+import { useAppSelector, useAppDispatch } from "store/hooks";
+import { userLoggedIn, userLoggedOut } from "store/features/user/authSlice";
+import {
+  setUserInfo,
+  userState,
+  selectEmail,
+  selectAvatarUrl,
+  selectName,
+} from "store/features/user/userSlice";
+import UserInfo from "./UserInfo";
 
 const UserProfile = () => {
+  const router = useRouter();
+  const { isLoggedIn } = useAppSelector((state) => state.auth);
+  const email = useAppSelector(selectEmail);
+  const avatarUrl = useAppSelector(selectAvatarUrl);
+  const name = useAppSelector(selectName);
+  const dispatch = useAppDispatch();
+
+  // 로그인 후 처리
+  useEffect(() => {
+    const getOAuthTokenPromise = new Promise((resolve, reject) => {
+      resolve(window.localStorage.getItem("oauth_provider_token"));
+    });
+
+    async function getOAuthTokenAndMovePage() {
+      const result = await getOAuthTokenPromise;
+      result !== null ? dispatch(userLoggedIn()) : dispatch(userLoggedOut());
+    }
+    getOAuthTokenAndMovePage();
+  }, [dispatch]);
+
+  if (isLoggedIn === true) {
+    const userToken: string = window.localStorage.getItem(
+      "sb-vifbaselokneezcalqdb-auth-token"
+    )!;
+    const { user } = JSON.parse(userToken);
+    const { avatar_url, email, full_name } = user.user_metadata;
+    const userData: userState = {
+      avatar_url: avatar_url,
+      email: email,
+      full_name: full_name,
+    };
+
+    dispatch(setUserInfo(userData));
+  } else {
+    console.log("사용자 데이터가 없습니다.");
+  }
+
+  //로그아웃
   async function signOut() {
     const { error } = await supabase.auth.signOut();
+    const dispatchPromise = new Promise((resolve, reject) => {
+      resolve(dispatch(userLoggedOut()));
+    });
+    if (!error) {
+      const result = await dispatchPromise;
 
-    if (!error) console.log("로그아웃 완료");
-    else console.log("로그아웃 실패", error.message);
+      if (result) {
+        alert("로그아웃이 완료 되었습니다.");
+        router.push("/");
+      } else alert("로그아웃 실패 [dispatch fail]");
+    } else alert("로그아웃 실패 [OAuth error]");
   }
 
   return (
@@ -22,11 +74,29 @@ const UserProfile = () => {
       title="계정 정보"
       extra={<Button onClick={signOut}>로그아웃</Button>}
     >
-      <p>Card content</p>
-      <p>Card content</p>
-      <p>Card content</p>
+      {/* <Image
+        src={avatarUrl}
+        width={60}
+        height={60}
+        alt="profile image"
+        style={{ borderRadius: "50%" }}
+      /> */}
+      <p>
+        <UserInfo>이름</UserInfo>
+        {name}
+      </p>
+      <p>
+        <UserInfo>이메일</UserInfo>
+        {email}
+      </p>
     </AccountBox>
   );
 };
+
+const AccountBox = styled(Card)`
+  width: 50%;
+  margin: auto;
+  margin-top: 100px;
+`;
 
 export default UserProfile;

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,16 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "http",
+        hostname: "k.kakaocdn.net",
+        port: "",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/store/features/user/userSlice.ts
+++ b/store/features/user/userSlice.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import type { RootState } from "store/store";
+
+export interface userState {
+  avatar_url: string;
+  full_name: string;
+  email: string;
+}
+
+const initialState: userState = {
+  avatar_url: "",
+  full_name: "",
+  email: "",
+};
+
+export const userSlice = createSlice({
+  name: "user",
+  initialState,
+  reducers: {
+    setUserInfo: (state, action: PayloadAction<userState>) => {
+      const { avatar_url, email, full_name } = action.payload;
+      state.avatar_url = avatar_url;
+      state.email = email;
+      state.full_name = full_name;
+    },
+  },
+});
+
+export const { setUserInfo } = userSlice.actions;
+export const selectAvatarUrl = (state: RootState) => state.user.avatar_url;
+export const selectEmail = (state: RootState) => state.user.email;
+export const selectName = (state: RootState) => state.user.full_name;
+export default userSlice.reducer;

--- a/store/store.ts
+++ b/store/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import authSliceReducer from "./features/user/authSlice";
+import userSliceReducer from "./features/user/userSlice";
 
 export const makeStore = () => {
   return configureStore({
     reducer: {
       auth: authSliceReducer,
+      user: userSliceReducer,
     },
   });
 };


### PR DESCRIPTION
## Type
- 기능 추가
<br>

## Motivation

- 로그인/로그아웃 후 로직 추가 필요.
- 유저 정보 저장을 위해 slice 생성 필요.

<br>

## Key Changes

- 우측 상단 유저 아이콘 클릭 시 상태에 따라 설정된 경로로 이동.
- 메인페이지 접속 시 로컬스토리지에 OAuth토큰이 존재하면 isLoggedIn 상태값 업데이트.
- 로그인, 로그아웃 후 isLoggedIn 상태값 업데이트.
- 유저 정보 저장을 위한 userSlice 생성 및 저장 로직 추가.
- 마에페이지에 계정 정보 조회됨.
![image](https://github.com/dnwn-9001/haru_camping/assets/106906742/ccc95833-4e9e-4b7e-9e38-351b504bc528)


